### PR TITLE
Bugfixes for filterList method.

### DIFF
--- a/01-Fundamentals/06-unidirectional-data-flow.html
+++ b/01-Fundamentals/06-unidirectional-data-flow.html
@@ -28,9 +28,9 @@
 		https://scotch.io/tutorials/learning-react-getting-started-and-concepts#unidirectional-data-flow
      */
 		var FilteredList = React.createClass({
-			filterList: (event) =>{
+			filterList: function (event) {
 				var updatedList = this.state.initialItems;
-				updatedList = updatedList.filter item => {
+				updatedList = updatedList.filter(item => {
 					return item.toLowerCase().search(
 						event.target.value.toLowerCase()) !== -1;
 				});


### PR DESCRIPTION
There was a missing open bracket in line 33.

The arrow-function autobinding of this doesn't work under createClass. I fixed it by going back to a non-ES6 function declaration. An alternative would be to use "class FilteredList extends React.Component" ... as in https://babeljs.io/blog/2015/06/07/react-on-es6-plus

Cheers
Michael
